### PR TITLE
Added routing for sidebar items

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^4.7.2",
     "web-vitals": "^2.1.4"
   },
-  "scripts": {
+  "scripts": { 
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "dev": "next dev",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import PlaygroundApp from "../src/App"
+
+function FourOhFour() {
+  return (
+    <PlaygroundApp />
+  );
+}
+
+export default FourOhFour;

--- a/pages/[type]/[key]/[variant].tsx
+++ b/pages/[type]/[key]/[variant].tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PlaygroundApp from "../../../src/App";
+import data from '../../../src/data.json';
+import { parseKey } from '../../../src/utils'
 
-const data = require('../../../src/data.json');
 const dataKeys = Object.keys(data) ?? [];
 
 const RoutePage = ({ parsedData }: { parsedData: any }) => {
@@ -10,32 +11,20 @@ const RoutePage = ({ parsedData }: { parsedData: any }) => {
   );
 }
 
-function parseKey(value: string): string {
-  const splitItems = value.split('-')
-  let str = ''
-  splitItems.forEach((splitItem) => {
-    str = `${str}${splitItem.charAt(0).toUpperCase()}${splitItem.slice(1)} `;
-  })
-
-  if (str.charAt(str.length - 1) === ' ')
-    return str.slice(0, str.length - 1);
-  return str;
-}
-
 function parseQuery(type: string, key: string, variant: string): object | null {
   const parsedType = parseKey(type);
   const parsedKey = parseKey(key);
   const parsedVariant = parseKey(variant);
-  if (parsedType == undefined || parsedKey == undefined) {
+  if (!parsedType || !parsedKey) {
     return null;
   }
   if (dataKeys.includes(parsedType)) {
-    const indexOfKey = data[parsedType].findIndex((i) => i.key == parsedKey);
+    const indexOfKey = data[parsedType].findIndex((i) => i.key.toLowerCase() == parsedKey.toLowerCase());
     if (indexOfKey !== -1) {
-      const indexOfVariant = data[parsedType][indexOfKey].variants.findIndex((i) => i == parsedVariant);
+      const sidebarItem = data[parsedType][indexOfKey];
+      const indexOfVariant = sidebarItem.variants.findIndex((i) => i == parsedVariant);
       if (indexOfVariant !== -1) {
-
-        return { ...data[parsedType][indexOfKey], globalKey: parsedType, index: indexOfVariant };
+        return { ...sidebarItem, globalKey: parsedType, index: indexOfVariant };
       }
     }
   }

--- a/pages/[type]/[key]/[variant].tsx
+++ b/pages/[type]/[key]/[variant].tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import PlaygroundApp from "../../../src/App";
+
+const data = require('../../../src/data.json');
+const dataKeys = Object.keys(data) ?? [];
+
+const RoutePage = ({ parsedData }: { parsedData: any }) => {
+  return (
+    <PlaygroundApp pageData={parsedData} />
+  );
+}
+
+function parseKey(value: string): string | undefined {
+  const splitItems = value.split('-')
+  let str = ''
+  splitItems.forEach((splitItem) => {
+    str = `${str}${splitItem.charAt(0).toUpperCase()}${splitItem.slice(1)} `;
+  })
+
+  if (str.charAt(str.length - 1) === ' ')
+    return str.slice(0, str.length - 1);
+  return str;
+}
+
+function parseQuery(type: string, key: string, variant: string): object | null {
+  const parsedType = parseKey(type);
+  const parsedKey = key.toString();
+  const parsedVariant = parseKey(variant);
+  if (parsedType == undefined || parsedKey == undefined) {
+    return null;
+  }
+  if (dataKeys.includes(parsedType)) {
+    const indexOfKey = data[parsedType].findIndex((i) => i.key.toLowerCase() == parsedKey);
+    if (indexOfKey !== -1) {
+      const indexOfVariant = data[parsedType][indexOfKey].variants.findIndex((i) => i == parsedVariant);
+      if (indexOfVariant !== -1) {
+        return { ...data[parsedType][indexOfKey], globalKey: parsedType, index: indexOfVariant };
+      }
+    }
+  }
+  return null;
+}
+
+export const getServerSideProps = async (context: any) => {
+  const { type, key, variant } = context.query
+
+  const parsedData = parseQuery(type, key, variant)
+
+  return {
+    props: {
+      parsedData: parsedData
+    }
+  }
+}
+
+export default RoutePage

--- a/pages/[type]/[key]/[variant].tsx
+++ b/pages/[type]/[key]/[variant].tsx
@@ -10,7 +10,7 @@ const RoutePage = ({ parsedData }: { parsedData: any }) => {
   );
 }
 
-function parseKey(value: string): string | undefined {
+function parseKey(value: string): string {
   const splitItems = value.split('-')
   let str = ''
   splitItems.forEach((splitItem) => {
@@ -24,16 +24,17 @@ function parseKey(value: string): string | undefined {
 
 function parseQuery(type: string, key: string, variant: string): object | null {
   const parsedType = parseKey(type);
-  const parsedKey = key.toString();
+  const parsedKey = parseKey(key);
   const parsedVariant = parseKey(variant);
   if (parsedType == undefined || parsedKey == undefined) {
     return null;
   }
   if (dataKeys.includes(parsedType)) {
-    const indexOfKey = data[parsedType].findIndex((i) => i.key.toLowerCase() == parsedKey);
+    const indexOfKey = data[parsedType].findIndex((i) => i.key == parsedKey);
     if (indexOfKey !== -1) {
       const indexOfVariant = data[parsedType][indexOfKey].variants.findIndex((i) => i == parsedVariant);
       if (indexOfVariant !== -1) {
+
         return { ...data[parsedType][indexOfKey], globalKey: parsedType, index: indexOfVariant };
       }
     }

--- a/pages/[type]/[key]/index.tsx
+++ b/pages/[type]/[key]/index.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import PlaygroundApp from "../../../src/App";
+
+const data = require('../../../src/data.json');
+const dataKeys = Object.keys(data) ?? [];
+
+const RoutePage = ({ parsedData }: { parsedData: any }) => {
+  return (
+    <PlaygroundApp pageData={parsedData} />
+  );
+}
+
+function parseKey(value: string): string | undefined {
+  const splitItems = value.split('-')
+  let str = ''
+  splitItems.forEach((splitItem) => {
+    str = `${str}${splitItem.charAt(0).toUpperCase()}${splitItem.slice(1)} `;
+  })
+
+  if (str.charAt(str.length - 1) === ' ')
+    return str.slice(0, str.length - 1);
+  return str;
+}
+
+function parseQuery(type: string, key: string): object | null {
+  const parsedType = parseKey(type);
+  const parsedKey = key.toString();
+  if (parsedType == undefined || parsedKey == undefined) {
+    return null;
+  }
+  if (dataKeys.includes(parsedType)) {
+    const indexOfKey = data[parsedType].findIndex((i) => i.key.toLowerCase() == parsedKey);
+    if (indexOfKey !== -1) {
+      return { ...data[parsedType][indexOfKey], globalKey: parsedType, index: 0 };
+    }
+  }
+  return null;
+}
+
+export const getServerSideProps = async (context: any) => {
+  const { type, key } = context.query
+
+  const parsedData = parseQuery(type, key)
+
+  return {
+    props: {
+      parsedData: parsedData
+    }
+  }
+}
+
+export default RoutePage

--- a/pages/[type]/[key]/index.tsx
+++ b/pages/[type]/[key]/index.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import PlaygroundApp from "../../../src/App";
+import data from '../../../src/data.json';
+import { parseKey } from "../../../src/utils";
 
-const data = require('../../../src/data.json');
 const dataKeys = Object.keys(data) ?? [];
 
 const RoutePage = ({ parsedData }: { parsedData: any }) => {
@@ -10,28 +11,17 @@ const RoutePage = ({ parsedData }: { parsedData: any }) => {
   );
 }
 
-function parseKey(value: string): string | undefined {
-  const splitItems = value.split('-')
-  let str = ''
-  splitItems.forEach((splitItem) => {
-    str = `${str}${splitItem.charAt(0).toUpperCase()}${splitItem.slice(1)} `;
-  })
-
-  if (str.charAt(str.length - 1) === ' ')
-    return str.slice(0, str.length - 1);
-  return str;
-}
-
 function parseQuery(type: string, key: string): object | null {
   const parsedType = parseKey(type);
   const parsedKey = key.toString();
-  if (parsedType == undefined || parsedKey == undefined) {
+  if (!parsedType || !parsedKey) {
     return null;
   }
   if (dataKeys.includes(parsedType)) {
-    const indexOfKey = data[parsedType].findIndex((i) => i.key.toLowerCase() == parsedKey);
+    const sidebarItem = data[parsedType];
+    const indexOfKey = sidebarItem.findIndex((i) => i.key.toLowerCase() == parsedKey.toLowerCase());
     if (indexOfKey !== -1) {
-      return { ...data[parsedType][indexOfKey], globalKey: parsedType, index: 0 };
+      return { ...sidebarItem[indexOfKey], globalKey: parsedType, index: 0 };
     }
   }
   return null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,36 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Drawer, styled } from '@mui/material'
 import Sidebar from './components/Sidebar/Sidebar'
 import Header from './components/Header/Header'
 import Body from './components/Body/Body'
 import { drawerWidth } from './constants'
+import { useRouter } from 'next/router'
 import { ToastContainer } from 'react-toastify'
 import theme from './theme'
-function PlaygroundApp() {
+import { useAppDispatch } from './redux/hooks'
+import { setSelectedItem, setSnippet } from './redux/slice'
+
+export type PlaygroundAppType = {
+  pageData?: any
+}
+
+function PlaygroundApp({ pageData }: PlaygroundAppType) {
   const [open, setOpen] = useState(true)
+  const dispatch = useAppDispatch()
+  const router = useRouter()
 
   const toggleDrawer = () => {
     setOpen(!open)
   }
+
+  useEffect(() => {
+    if (pageData !== null && pageData !== undefined) {
+      dispatch(setSelectedItem(pageData))
+      dispatch(setSnippet(pageData.snippets[pageData.index]))
+    } else if (router.asPath !== '/') {
+      router.replace('/')
+    }
+  }, [pageData])
 
   const DrawerHeader = styled('div')(({ theme }) => ({
     display: 'flex',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function PlaygroundApp({ pageData }: PlaygroundAppType) {
   }
 
   useEffect(() => {
-    if (pageData !== null && pageData !== undefined) {
+    if (pageData) {
       dispatch(setSelectedItem(pageData))
       dispatch(setSnippet(pageData.snippets[pageData.index]))
     } else if (router.asPath !== '/') {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -5,8 +5,8 @@ import { drawerWidth } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setSelectedItem, setSnippet } from '../../redux/slice';
 import ExpandableListItem from './ExpandableListItem';
+import data from '../../data.json';
 
-const data = require('../../data.json');
 const dataKeys = Object.keys(data) ?? [];
 
 const Sidebar = () => {
@@ -17,7 +17,7 @@ const Sidebar = () => {
 
   useEffect(() => {
     const firstKey = dataKeys.length > 0 ? dataKeys[0] : ''
-    const objectData = { ...data[firstKey][0], globalKey: firstKey, index: 0 }
+    const objectData = { ...(data as any)[firstKey][0], globalKey: firstKey, index: 0 }
     dispatch(setSelectedItem(objectData))
     dispatch(setSnippet(objectData.snippets[objectData.index]))
   }, [])
@@ -38,7 +38,7 @@ const Sidebar = () => {
             pt: '4px',
             pb: '4px',
           }} title={key}>
-            {(data[key]).map((item: any, index: number) => {
+            {((data as any)[key]).map((item: any, index: number) => {
               if (item.variants.length === 1) {
                 return <ListItemButton selected={selectedItem.globalKey === key && selectedItem.key === item.key}
                   sx={{

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -71,7 +71,7 @@ const Sidebar = () => {
                       },
                     }}
                     onClick={() => {
-                      router.push(`/${parseKeyToString(key)}/${item.key.toLowerCase()}/${parseKeyToString(subItem)}`)
+                      router.push(`/${parseKeyToString(key)}/${parseKeyToString(item.key)}/${parseKeyToString(subItem)}`)
                     }}>
                     <ListItemText primary={subItem} />
                   </ListItemButton>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { List, ListItemButton, ListItemText } from '@mui/material';
 import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 import { drawerWidth } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
 import { setSelectedItem, setSnippet } from '../../redux/slice';
@@ -10,16 +11,21 @@ const dataKeys = Object.keys(data) ?? [];
 
 const Sidebar = () => {
 
+  const router = useRouter();
   const dispatch = useAppDispatch()
   const selectedItem = useAppSelector((state) => state.code.selectedItem)
 
   useEffect(() => {
     const firstKey = dataKeys.length > 0 ? dataKeys[0] : ''
-    const objectData = { ...(data as any)[firstKey][0], globalKey: firstKey, index: 0 }
+    const objectData = { ...data[firstKey][0], globalKey: firstKey, index: 0 }
     dispatch(setSelectedItem(objectData))
     dispatch(setSnippet(objectData.snippets[objectData.index]))
   }, [])
 
+
+  const parseKeyToString = (key: string) => {
+    return key.toLowerCase().replaceAll(' ', '-');
+  }
 
   return <div>
     <div className='side-container'>
@@ -32,9 +38,9 @@ const Sidebar = () => {
             pt: '4px',
             pb: '4px',
           }} title={key}>
-            {((data as any)[key]).map((item: any, index: number) => {
+            {(data[key]).map((item: any, index: number) => {
               if (item.variants.length === 1) {
-                return <ListItemButton selected={selectedItem.globalKey === key && selectedItem.key === item.key && selectedItem.index === index}
+                return <ListItemButton selected={selectedItem.globalKey === key && selectedItem.key === item.key}
                   sx={{
                     pl: 4,
                     '&.Mui-selected': {
@@ -42,9 +48,7 @@ const Sidebar = () => {
                     },
                   }}
                   onClick={() => {
-                    const resp = { ...item, index: 0, globalKey: key }
-                    dispatch(setSelectedItem(resp))
-                    dispatch(setSnippet(resp.snippets[resp.index]))
+                    router.push(`/${parseKeyToString(key)}/${item.key.toLowerCase()}/`)
                   }}>
                   <ListItemText primary={item.key} />
                 </ListItemButton>
@@ -67,9 +71,7 @@ const Sidebar = () => {
                       },
                     }}
                     onClick={() => {
-                      const resp = { ...item, index: index, globalKey: key }
-                      dispatch(setSelectedItem(resp))
-                      dispatch(setSnippet(resp.snippets[resp.index]))
+                      router.push(`/${parseKeyToString(key)}/${item.key.toLowerCase()}/${parseKeyToString(subItem)}`)
                     }}>
                     <ListItemText primary={subItem} />
                   </ListItemButton>

--- a/src/data.json
+++ b/src/data.json
@@ -133,7 +133,7 @@
       ],
       "snippets": [
         "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst spaceId = '1'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.spaceFollows.unfollowSpace(spaceId)\ntx.signAndSend(pair, logger)",
-        "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst accountIdToFollow = '5HYYeCa1Hae5YYGJ2pHskHLVrA7V5WjaSuSbntidhhD9qqgs'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.accountFollows.unfollowAccount(accountIdToFollow)\ntx.signAndSend(pair, logger)"
+        "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst accountIdToUnfollow = '5HYYeCa1Hae5YYGJ2pHskHLVrA7V5WjaSuSbntidhhD9qqgs'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.accountFollows.unfollowAccount(accountIdToUnfollow)\ntx.signAndSend(pair, logger)"
       ]
     }
   ]

--- a/src/data.json
+++ b/src/data.json
@@ -133,7 +133,7 @@
       ],
       "snippets": [
         "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst spaceId = '1'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.spaceFollows.unfollowSpace(spaceId)\ntx.signAndSend(pair, logger)",
-        "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst accountIdToFollow = '5HYYeCa1Hae5YYGJ2pHskHLVrA7V5WjaSuSbntidhhD9qqgs'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.accountFollows.followAccount(accountIdToFollow)\ntx.signAndSend(pair, logger)"
+        "const pair = keyring.addFromMnemonic('bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice')\n\nconst accountIdToFollow = '5HYYeCa1Hae5YYGJ2pHskHLVrA7V5WjaSuSbntidhhD9qqgs'\nconst substrateApi = await api.blockchain.api\nconst tx = substrateApi.tx.accountFollows.unfollowAccount(accountIdToFollow)\ntx.signAndSend(pair, logger)"
       ]
     }
   ]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+export function parseKey(value: string): string {
+  const splitItems = value.split('-')
+  let str = ''
+  splitItems.forEach((splitItem) => {
+    str = `${str}${splitItem.charAt(0).toUpperCase()}${splitItem.slice(1)} `;
+  })
+
+  str = str.trim()
+  return str;
+}


### PR DESCRIPTION
## Description

- Added separate pages for [variant] & index because there might be some cases where no or only variant exists in data.json
- Handling 404 cases to show the primary landing page route 
- Handled /reading-data/space/by-id but when searched it changes to / route as it's the entry point.